### PR TITLE
fix(release): extract JSON from publish output

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -100,7 +100,9 @@ export default async function runExecutor(
 
       const jsonRegex = /\{(?:[^{}])*\}/g;
       const jsonObjectsInOutput = result.toString().match(jsonRegex);
-      const resultJson = JSON.parse(jsonObjectsInOutput[jsonObjectsInOutput.length - 1]);
+      const resultJson = JSON.parse(
+        jsonObjectsInOutput[jsonObjectsInOutput.length - 1]
+      );
 
       const distTags = resultJson['dist-tags'] || {};
       if (distTags[tag] === currentVersion) {

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -98,7 +98,10 @@ export default async function runExecutor(
         stdio: ['ignore', 'pipe', 'pipe'],
       });
 
-      const resultJson = JSON.parse(result.toString());
+      const jsonRegex = /\{(?:[^{}])*\}/g;
+      const jsonObjectsInOutput = result.toString().match(jsonRegex);
+      const resultJson = JSON.parse(jsonObjectsInOutput[jsonObjectsInOutput.length - 1]);
+
       const distTags = resultJson['dist-tags'] || {};
       if (distTags[tag] === currentVersion) {
         console.warn(


### PR DESCRIPTION
Instead of parsing the raw output of the npm publish command, only use the last JSON structure within the text

closed #22925

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
